### PR TITLE
在postinst脚本中将文管守护进程设置为开机自启

### DIFF
--- a/debian/dfmplugin-disk-encrypt.postinst
+++ b/debian/dfmplugin-disk-encrypt.postinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Enable dde-filemanager-daemon.service"
+systemctl enable dde-filemanager-daemon.service


### PR DESCRIPTION
some operation must be executed when system launch, the daemon process
is launched by desktop or file manager, if user never login system after
triggered a fstab disk encryption, the initramfs is never updated,
initrd do not know some disks should be unlocked before mount, cause the
system block on launch and cannot be repaired.

Log: enable file manager daemon
