### PR TITLE
加解密时显示了多个进度对话框

### DIFF
--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.cpp
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.cpp
@@ -267,34 +267,35 @@ void DiskEncryptDBus::setToken(const QString &dev, const QString &token)
         qWarning() << "set token failed for device" << dev;
 }
 
-void DiskEncryptDBus::triggerReencrypt()
+bool DiskEncryptDBus::triggerReencrypt()
 {
     QString clearDev;
     if (!readEncryptDevice(&currentEncryptingDevice, &clearDev, &deviceName)) {
-        qInfo() << "no encrypt config or config is invalid.";
-        return;
+        qWarning() << "no encrypt config or config is invalid.";
+        return false;
     }
 
     QFile devHandler("/dev/usec_crypt");
     if (!devHandler.exists()) {
         qWarning() << "no device handler exists!";
-        return;
+        return false;
     }
 
     if (!devHandler.open(QIODevice::WriteOnly)) {
         qWarning() << "device handler open failed!";
-        return;
+        return false;
     }
 
     if (0 > devHandler.write(clearDev.toLocal8Bit())) {
         qWarning() << "reencrypt trigger failed!";
         devHandler.close();
-        return;
+        return false;
     }
 
     qInfo() << "about to start encrypting" << clearDev;
 
     devHandler.close();
+    return true;
 }
 
 void DiskEncryptDBus::diskCheck()

--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.h
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.h
@@ -45,7 +45,7 @@ private:
     bool checkAuth(const QString &actID);
     void startReencrypt(const QString &dev, const QString &passphrase, const QString &token, int cipherPos, int recPos);
     void setToken(const QString &dev, const QString &token);
-    void triggerReencrypt();
+    bool triggerReencrypt();
     void diskCheck();
     static void getDeviceMapper(QMap<QString, QString> *dev2uuid, QMap<QString, QString> *uuid2dev);
     static bool updateCrypttab();

--- a/src/dde-file-manager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/dde-file-manager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -33,6 +33,15 @@ EventsHandler *EventsHandler::instance()
 
 void EventsHandler::bindDaemonSignals()
 {
+    // FIXME(xust) split the unlock module into another plugin.
+    // for unlocking devices in file dialog, this plugin is loaded,
+    // which cause when en/decrypt devices, the signal are handled
+    // by both file manager and file dialog, so multiple progress
+    // dialog and finished dialog are shown.
+    // this class is singleton but in different process it's not.
+    if (qApp->applicationName() != "dde-file-manager")
+        return;
+
     auto conn = [this](const char *sig, const char *slot) {
         QDBusConnection::systemBus().connect(kDaemonBusName,
                                              kDaemonBusPath,


### PR DESCRIPTION
the eventshandler class is singleton in single process, but while the
file chooser loaded the plugin, it's not 'singleton', the dialog and the
file manger both captured the progress/finished signal and shown the
dialogs.
it's not a good solution, the unlock logic should be split into a
seperated plugin, and the file chooser only need load it.
i left a FIXME and hope someday i will refact it.

Log: fix issue about dialogs

Bug: https://pms.uniontech.com/bug-view-237447.html
