### PR TITLE
feat: [encrypt] the new way to encrypt fstab disks.

### DIFF
--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.h
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.h
@@ -26,6 +26,7 @@ public Q_SLOTS:
     QString DecryptDisk(const QVariantMap &params);
     QString ChangeEncryptPassphress(const QVariantMap &params);
     QString QueryTPMToken(const QString &device);
+    void SetEncryptParams(const QVariantMap &params);
 
 Q_SIGNALS:
     void PrepareEncryptDiskResult(const QString &device, const QString &devName, const QString &jobID, int errCode);
@@ -34,10 +35,9 @@ Q_SIGNALS:
     void ChangePassphressResult(const QString &device, const QString &devName, const QString &jobID, int errCode);
     void EncryptProgress(const QString &device, const QString &devName, double progress);
     void DecryptProgress(const QString &device, const QString &devName, double progress);
+    void RequestEncryptParams(const QVariantMap &encConfig);
 
 private Q_SLOTS:
-    void onEncryptDBusRegistered(const QString &service);
-    void onEncryptDBusUnregistered(const QString &service);
     void onFstabDiskEncProgressUpdated(const QString &dev, qint64 offset, qint64 total);
     void onFstabDiskEncFinished(const QString &dev, int result, const QString &errstr);
 
@@ -51,10 +51,7 @@ private:
     static bool updateCrypttab();
     static int isEncrypted(const QString &target, const QString &source);
 
-    bool readEncryptDevice(QString *backingDev, QString *clearDev, QString *devName);
-
 private:
-    QSharedPointer<QDBusServiceWatcher> watcher;
     QString currentEncryptingDevice;
     QString deviceName;
 };

--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/encrypt/diskencrypt.h
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/encrypt/diskencrypt.h
@@ -14,27 +14,36 @@ class DBlockDevice;
 
 FILE_ENCRYPT_BEGIN_NS
 
-enum EncryptStatus {
+enum EncryptVersion {
     kNotEncrypted,
-    kLUKS1,
-    kLUKS2,
-    kUnknownLUKS,
+    kVersionLUKS1,
+    kVersionLUKS2,
+    kVersionLUKSUnknown,
 
-    kStatusError = 10000,
-};   // enum EncryptStatus
+    kVersionUnknown = 10000,
+};   // enum EncryptVersion
+
+enum EncryptStatus {
+    kStatusFinished,
+    kStatusOfflineUnfinished,
+    kStatusOnlineUnfinished,
+
+    kStatusUnknown = 10000
+};
 
 namespace disk_encrypt_funcs {
 int bcInitHeaderFile(const EncryptParams &params, QString &headerPath, int *keyslotCipher, int *keyslotRecKey);
 int bcGetToken(const QString &device, QString *tokenJson);
 int bcInitHeaderDevice(const QString &device, const QString &passphrase, const QString &headerPath);
 int bcSetToken(const QString &device, const QString &token);
-int bcResumeReencrypt(const QString &device, const QString &passphrase);
+int bcResumeReencrypt(const QString &device, const QString &passphrase, const QString &clearDev, bool expandFs = true);
 int bcChangePassphrase(const QString &device, const QString &oldPassphrase, const QString &newPassphrase, int *keyslot);
 int bcChangePassphraseByRecKey(const QString &device, const QString &oldPassphrase, const QString &newPassphrase, int *keyslot);
 int bcDecryptDevice(const QString &device, const QString &passphrase);
 int bcBackupCryptHeader(const QString &device, QString &headerPath);
 int bcDoSetupHeader(const EncryptParams &params, QString *headerPath, int *keyslotCipher, int *keyslotRecKey);
 int bcPrepareHeaderFile(const QString &device, QString *headerPath);
+int bcSetLabel(const QString &device, const QString &label);
 
 int bcEncryptProgress(uint64_t size, uint64_t offset, void *usrptr);
 int bcDecryptProgress(uint64_t size, uint64_t offset, void *usrptr);
@@ -44,6 +53,7 @@ int bcDecryptProgress(uint64_t size, uint64_t offset, void *usrptr);
 namespace disk_encrypt_utils {
 EncryptParams bcConvertParams(const QVariantMap &params);
 bool bcValidateParams(const EncryptParams &params);
+bool bcReadEncryptConfig(disk_encrypt::EncryptConfig *config);
 
 QString bcExpRecFile(const EncryptParams &params);
 QString bcGenRecKey();
@@ -52,7 +62,8 @@ QString bcGenRecKey();
 typedef QSharedPointer<dfmmount::DBlockDevice> DevPtr;
 namespace block_device_utils {
 DevPtr bcCreateBlkDev(const QString &device);
-EncryptStatus bcDevStatus(const QString &device);
+EncryptVersion bcDevEncryptVersion(const QString &device);
+int bcDevEncryptStatus(const QString &device, EncryptStatus *status);
 bool bcIsMounted(const QString &device);
 }   // namespace block_device_utils
 

--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/globaltypesdefine.h
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/globaltypesdefine.h
@@ -7,8 +7,11 @@
 
 #include <QString>
 #include <QStringList>
+#include <QVariantMap>
 
 namespace disk_encrypt {
+
+inline constexpr char kEncConfigPath[] { "/boot/usec-crypt/encrypt.json" };
 
 namespace encrypt_param_keys {
 inline constexpr char kKeyDevice[] { "device" };
@@ -24,6 +27,8 @@ inline constexpr char kKeyTPMConfig[] { "tpmConfig" };
 inline constexpr char kKeyTPMToken[] { "tpmToken" };
 inline constexpr char kKeyValidateWithRecKey[] { "usingRecKey" };
 inline constexpr char kKeyDeviceName[] { "deviceName" };
+inline constexpr char kKeyBackingDevUUID[] { "backingDevUUID" };
+inline constexpr char kKeyClearDevUUID[] { "clearDevUUID" };
 }   // namespace encrypt_param_keys
 
 inline const QStringList kDisabledEncryptPath {
@@ -66,6 +71,7 @@ enum EncryptOperationStatus {
     kErrorSetTokenFailed,
     kErrorResizeFs,
     kErrorDisabledMountPoint,
+    kErrorSetLabel,
 
     kErrorUnknown,
 };
@@ -88,6 +94,32 @@ struct DeviceEncryptParam
     QString mountPoint;
     bool initOnly;
     bool validateByRecKey;
+    QString backingDevUUID;
+    QString clearDevUUID;
+};
+
+struct EncryptConfig
+{
+    QString cipher;
+    QString device;
+    QString mountPoint;
+    QString deviceName;
+    QString devicePath;
+    QString keySize;
+    QString mode;
+    QString recoveryPath;
+    QVariantMap tpmConfig;
+    QString clearDev;
+
+    QVariantMap keyConfig()
+    {
+        return QVariantMap {
+            { "device", device },
+            { "device-path", devicePath },
+            { "device-name", deviceName },
+            { "volume", clearDev },
+        };
+    };
 };
 
 }

--- a/src/dde-file-manager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/dde-file-manager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -9,6 +9,7 @@
 
 namespace dfmplugin_diskenc {
 class EncryptProgressDialog;
+class EncryptParamsInputDialog;
 class EventsHandler : public QObject
 {
     Q_OBJECT
@@ -26,6 +27,7 @@ private Q_SLOTS:
     void onDecryptResult(const QString &, const QString &, const QString &, int);
     void onDecryptProgress(const QString &, const QString &, double);
     void onChgPassphraseResult(const QString &, const QString &, const QString &, int);
+    void onRequestEncryptParams(const QVariantMap &encConfig);
 
     QString acquirePassphrase(const QString &dev, bool &cancelled);
     QString acquirePassphraseByPIN(const QString &dev, bool &cancelled);
@@ -42,9 +44,10 @@ private Q_SLOTS:
 
 private:
     explicit EventsHandler(QObject *parent = nullptr);
-    
+
     QMap<QString, EncryptProgressDialog *> encryptDialogs;
     QMap<QString, EncryptProgressDialog *> decryptDialogs;
+    QMap<QString, EncryptParamsInputDialog *> encryptInputs;
 signals:
 };
 }

--- a/src/dde-file-manager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
+++ b/src/dde-file-manager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
@@ -44,6 +44,8 @@ public:
     virtual bool triggered(QAction *action) override;
     virtual void updateState(QMenu *parent) override;
 
+    static void doReencryptDevice(const disk_encrypt::DeviceEncryptParam &param);
+
 protected:
     static void encryptDevice(const disk_encrypt::DeviceEncryptParam &param);
     static void deencryptDevice(const disk_encrypt::DeviceEncryptParam &param);

--- a/src/dde-file-manager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/dde-file-manager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -24,9 +24,6 @@
 Q_DECLARE_METATYPE(bool *)
 Q_DECLARE_METATYPE(QString *)
 
-#define DEV_ENCTYPE_CFG "/etc/deepin/dde-file-manager/dev_enc_type.ini"
-#define DEV_KEY QString("device/%1")
-
 using namespace dfmplugin_diskenc;
 
 bool config_utils::exportKeyEnabled()


### PR DESCRIPTION
as title.
usec module only create an empty-passphrase header, dfm ask for user
input before trigger reencryption.

Log: as title.

Task: https://pms.uniontech.com/task-view-324375.html
