### PR TITLE
fix: [encrypt] non-fstab device cannot be encrypted.

### DIFF
--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/encrypt/diskencrypt.cpp
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/encrypt/diskencrypt.cpp
@@ -481,8 +481,10 @@ int disk_encrypt_funcs::bcResumeReencrypt(const QString &device,
                "wrong flags " + device + " flags " + QString::number(flags),
                -kErrorWrongFlags);
 
+    std::string _clearDev = clearDev.toStdString();
+    const char *__clearDev = clearDev.isEmpty() ? nullptr : _clearDev.c_str();
     ret = crypt_reencrypt_init_by_passphrase(cdev,
-                                             clearDev.toStdString().c_str(),
+                                             __clearDev,
                                              passphrase.toStdString().c_str(),
                                              passphrase.length(),
                                              CRYPT_ANY_SLOT,


### PR DESCRIPTION
as title.
the clearDev should be nullptr, empty string is not acceptable.

Log: as title.
