### PR TITLE
fix: [encrypt] cannot find encrypt config.

### DIFF
--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.cpp
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.cpp
@@ -266,7 +266,7 @@ bool DiskEncryptDBus::triggerReencrypt(const QString &device)
                 // pick a new job.
                 const static QRegularExpression reg(R"(encrypt_(.*).json)");
                 QDir usecDir("/boot/usec-crypt");
-                auto files = usecDir.entryInfoList();
+                auto files = usecDir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot);
                 for (const auto &file : files) {
                     auto fileName = file.fileName();
                     if (fileName.contains(reg)) {

--- a/src/dde-file-manager-daemon/daemonplugin-file-encrypt/encrypt/diskencrypt.cpp
+++ b/src/dde-file-manager-daemon/daemonplugin-file-encrypt/encrypt/diskencrypt.cpp
@@ -749,6 +749,10 @@ bool disk_encrypt_utils::bcReadEncryptConfig(disk_encrypt::EncryptConfig *config
     QFile encConfig(encryptConfigPath);
     if (!encConfig.exists()) {
         qInfo() << "the encrypt config file doesn't exist";
+        if (encryptConfigPath != kEncConfigPath) {
+            qInfo() << "try trigger default encrypt device.";
+            return bcReadEncryptConfig(config, "");
+        }
         return false;
     }
 


### PR DESCRIPTION
trigger encryption by default config if named config doesn't  exist.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-247415.html
