### PR TITLE
TPM 秘钥获取失败后主动弹出输入恢复秘钥的对话框

### DIFF
--- a/src/dde-file-manager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/dde-file-manager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -362,7 +362,8 @@ bool EventsHandler::onAcquireDevicePwd(const QString &dev, QString *pwd, bool *c
 
         dialog_utils::showDialog(title, tr("Please use recovery key to unlock device."),
                                  dialog_utils::kInfo);
-        *cancelled = true;
+
+        *pwd = acquirePassphraseByRec(dev, *cancelled);
     }
 
     return true;


### PR DESCRIPTION
when decrypt string from TPM failed, use recovery key to unlock device.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-265033.html