### PR TITLE
chore: [diskencrypt] remove the useless code.

### DIFF
--- a/src/dde-file-manager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/dde-file-manager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -449,9 +449,8 @@ QString DiskEncryptMenuScene::generateTPMConfig()
 {
     QString sessionHashAlgo, sessionKeyAlgo, primaryHashAlgo, primaryKeyAlgo, minorHashAlgo, minorKeyAlgo;
     if (!tpm_passphrase_utils::getAlgorithm(&sessionHashAlgo, &sessionKeyAlgo, &primaryHashAlgo, &primaryKeyAlgo, &minorHashAlgo, &minorKeyAlgo)) {
-        qWarning() << "cannot choose algorithm for tpm";
-        primaryHashAlgo = "sha256";
-        primaryKeyAlgo = "ecc";
+        qCritical() << "cannot choose algorithm for tpm";
+        return "";
     }
 
     QJsonObject tpmParams;


### PR DESCRIPTION
-- The code is useless, so remove it.

Log: fix issue

## Summary by Sourcery

Enhancements:
- Abort TPM config generation immediately on algorithm retrieval failure instead of falling back to default values and update log level to critical.