### PR TITLE
fix: resolve crash when stopping plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus.xml
 src/dde-file-manager-daemon/daemonplugin-file-encrypt/dbus/diskencryptdbus_adaptor.*
 
 debian/dde-desktop-videowallpaper-plugin.install
+
+.cursor/*
+.cache/*

--- a/src/dde-file-manager/dfmplugin-cooperation/cooperationplugin.cpp
+++ b/src/dde-file-manager/dfmplugin-cooperation/cooperationplugin.cpp
@@ -25,7 +25,7 @@ using namespace dfmplugin_cooperation;
 void CooperationPlugin::initialize()
 {
     deepin_cross::ReportLogManager::instance()->init();
-    auto translator = new QTranslator(this);
+    auto translator = new QTranslator(qApp);
     translator->load(QLocale(), "cooperation-transfer", "_", "/usr/share/dde-file-manager/translations");
     QCoreApplication::installTranslator(translator);
 


### PR DESCRIPTION
- Fix crash issue caused by translator instance being deleted while qApp still using it
- Add .cache and .cursor to .gitignore ignore list

Problem:
When plugins are stopped, the translator instance is deleted with its parent object,
but qApp is still using the instance, causing a crash.

Solution:
- Optimize translator instance lifecycle management
- Ensure translator instance is released after qApp stops using it

Task: https://pms.uniontech.com/task-view-378321.html

## Summary by Sourcery

Prevent crashes when stopping plugins by re-parenting the translator instance to qApp and update .gitignore

Bug Fixes:
- Re-parent QTranslator to qApp to ensure it remains alive while qApp uses it, avoiding deletion-related crashes

Chores:
- Add .cache and .cursor entries to .gitignore